### PR TITLE
Fixed member spelling mistake, tests passing

### DIFF
--- a/quick-attendance-api/dal/group.ts
+++ b/quick-attendance-api/dal/group.ts
@@ -34,7 +34,7 @@ export async function get_groups_for_account(user_id: Uuid) {
       KvHelper.map_to_kvs("group", account_entity.fk_managed_group_ids),
     ),
   );
-  const memeber_groups_promise = KvHelper.remove_kv_nones_async(
+  const member_groups_promise = KvHelper.remove_kv_nones_async(
     KvHelper.get_many_return_empty<GroupEntity[]>(
       kv,
       KvHelper.map_to_kvs("group", account_entity.fk_member_group_ids),
@@ -45,7 +45,7 @@ export async function get_groups_for_account(user_id: Uuid) {
   const groups = await Promise.all([
     owned_groups_promise,
     managed_groups_promise,
-    memeber_groups_promise,
+    member_groups_promise,
   ]);
 
   // Collect the unique owner id's here, this is to prevent the extra
@@ -84,7 +84,7 @@ export async function get_groups_for_account(user_id: Uuid) {
   return {
     owned_groups: to_sparse_model(groups[0]),
     managed_groups: to_sparse_model(groups[1]),
-    memeber_groups: to_sparse_model(groups[2]),
+    member_groups: to_sparse_model(groups[2]),
   } as GroupListGetRes;
 }
 
@@ -161,7 +161,7 @@ export async function create_group(owner_id: Uuid, req: GroupPostReq) {
     event_count: 0,
     manager_ids: null,
     member_ids: null,
-    pending_memeber_ids: null,
+    pending_member_ids: null,
     current_attendance_id: null,
   } as GroupEntity;
 
@@ -210,8 +210,8 @@ export async function accounts_for_group_invite(
     [get_accounts_by_usernames(invitees_usernames), get_group(group_id)],
   );
 
-  group_entity.value.pending_memeber_ids = add_to_maybe_set(
-    group_entity.value.pending_memeber_ids,
+  group_entity.value.pending_member_ids = add_to_maybe_set(
+    group_entity.value.pending_member_ids,
     account_entities.map((x) => x.value.user_id),
     HttpStatusCode.CONFLICT,
     (k) =>
@@ -271,7 +271,7 @@ export async function respond_to_group_invite(
     }
   }
 
-  if (!group_entity.pending_memeber_ids?.delete(user_id)) {
+  if (!group_entity.pending_member_ids?.delete(user_id)) {
     DbErr.err("Invite not found", HttpStatusCode.CONFLICT);
   }
 
@@ -288,7 +288,7 @@ export async function respond_to_group_invite(
       group_entity.member_ids,
       [user_id],
       HttpStatusCode.CONFLICT,
-      () => "User is already a memeber",
+      () => "User is already a member",
     );
   }
 

--- a/quick-attendance-api/endpoints/group.ts
+++ b/quick-attendance-api/endpoints/group.ts
@@ -53,7 +53,7 @@ group.get(
       return ctx.json(get_group_res);
     }
 
-    const memeber_get_promise = account_dal.get_public_account_models(
+    const member_get_promise = account_dal.get_public_account_models(
       group.member_ids?.entries().map((x) => x[0]).toArray() ?? [],
     );
     const manager_get_promise = account_dal.get_public_account_models(
@@ -75,7 +75,7 @@ group.get(
 
     const account_promises = await Promise.all([
       owner_get_promise,
-      memeber_get_promise,
+      member_get_promise,
       manager_get_promise,
       pending_accounts,
     ]);
@@ -83,7 +83,7 @@ group.get(
     get_group_res.owner = account_promises[0][0];
     get_group_res.members = account_promises[1];
     get_group_res.managers = account_promises[2];
-    get_group_res.pending_memebers = account_promises[3];
+    get_group_res.pending_members = account_promises[3];
 
     return ctx.json(get_group_res, HttpStatusCode.OK);
   },

--- a/quick-attendance-api/entities/group_entity.ts
+++ b/quick-attendance-api/entities/group_entity.ts
@@ -5,7 +5,7 @@ export interface GroupEntity {
   owner_id: Uuid;
   manager_ids: Set<Uuid> | null;
   member_ids: Set<Uuid> | null;
-  pending_memeber_ids: Set<Uuid> | null;
+  pending_member_ids: Set<Uuid> | null;
   group_name: string;
   group_description: string | null;
   current_attendance_id: Uuid | null;

--- a/quick-attendance-api/models/group/group_get_res.ts
+++ b/quick-attendance-api/models/group/group_get_res.ts
@@ -6,7 +6,7 @@ export interface GroupGetRes {
   owner: PublicAccountGetModel;
   managers: PublicAccountGetModel[] | null;
   members: PublicAccountGetModel[] | null;
-  pending_memebers: PublicAccountGetModel[] | null;
+  pending_members: PublicAccountGetModel[] | null;
   group_name: string;
   group_description: string | null;
   current_attendance_id: Uuid | null;

--- a/quick-attendance-api/models/group/group_list_res.ts
+++ b/quick-attendance-api/models/group/group_list_res.ts
@@ -3,5 +3,5 @@ import { GroupSparseGetModel } from "./group_sparse_get_model.ts";
 export interface GroupListGetRes {
   owned_groups: GroupSparseGetModel[];
   managed_groups: GroupSparseGetModel[];
-  memeber_groups: GroupSparseGetModel[];
+  member_groups: GroupSparseGetModel[];
 }

--- a/quick-attendance-api/tests/test_group_invite_and_join_test.ts
+++ b/quick-attendance-api/tests/test_group_invite_and_join_test.ts
@@ -60,7 +60,7 @@ Deno.test(
           user_rocco_mason.username,
       );
       assert(owner_group_list.managed_groups.length === 0);
-      assert(owner_group_list.memeber_groups.length === 0);
+      assert(owner_group_list.member_groups.length === 0);
 
       await test_fetch_json(GROUP_AUTH_URL(test_num) + "/invite", "PUT", owner_jwt, {
         "usernames": invite_members.map((x) => x.user_data.username),
@@ -134,7 +134,7 @@ Deno.test(
             const group = (await res.json()) as GroupGetRes;
             return group.event_count === 0 && group.group_name === "Rocco's group of friends" &&
               group.members?.length === 2 && group.members.every((x) => x.unique_id === null) &&
-              group.pending_memebers === null;
+              group.pending_members === null;
           },
         );
       }


### PR DESCRIPTION
Fixed bad spelling that was propagated throughout the Deno API layer