### PR TITLE
API layer now determines the users type

### DIFF
--- a/quick-attendance-api/endpoints/group.ts
+++ b/quick-attendance-api/endpoints/group.ts
@@ -13,10 +13,11 @@ import { group_unique_id_settings_get_req } from "../models/group/group_unique_i
 import { group_invite_jwt_payload } from "../models/group_invite_jwt_payload.ts";
 import { GroupPostRes } from "../models/group/group_post_res.ts";
 import { group_get_req } from "../models/group/group_get_req.ts";
-import { is_privileged_user_type } from "../models/user_type.ts";
+import { is_privileged_user_type, UserType } from "../models/user_type.ts";
 import { GroupGetRes } from "../models/group/group_get_res.ts";
 import { PublicAccountGetModel } from "../models/account/public_account_get_model.ts";
 import { get_alphanumeric_str } from "../util/csharp-utils.ts";
+import { HTTPException } from "@hono/hono/http-exception";
 
 const group_base_path = "/group";
 const auth_group_base_path = `/auth${group_base_path}`;
@@ -32,10 +33,26 @@ group.get(
   async (ctx) => {
     const req = ctx.req.valid("query");
     const user_id = get_jwt_payload(ctx).user_id;
+
+    // Determine what the type of the user is
+    const account = await account_dal.get_account(user_id);
+    let user_type: UserType;
+    if (account.fk_owned_group_ids?.has(req.group_id) === true) {
+      user_type = UserType.Owner;
+    } else if (account.fk_managed_group_ids?.has(req.group_id) === true) {
+      user_type = UserType.Manager;
+    } else if (account.fk_member_group_ids?.has(req.group_id) === true) {
+      user_type = UserType.Member;
+    } else {
+      throw new HTTPException(HttpStatusCode.NOT_FOUND, {
+        message: "User does not belong to the specified group",
+      });
+    }
+
     const group = await dal.get_group_and_verify_user_type(
       req.group_id,
       user_id,
-      req.user_type,
+      user_type,
     );
 
     const get_group_res = {
@@ -67,7 +84,7 @@ group.get(
       null as PublicAccountGetModel[] | null,
     );
 
-    if (is_privileged_user_type(req.user_type)) {
+    if (is_privileged_user_type(user_type)) {
       pending_accounts = account_dal.get_public_account_models(
         group.manager_ids?.entries().map((x) => x[0]).toArray() ?? [],
       );

--- a/quick-attendance-api/models/group/group_get_req.ts
+++ b/quick-attendance-api/models/group/group_get_req.ts
@@ -1,10 +1,8 @@
 import { z } from "zod";
 import { val_uuid_zod } from "../../util/uuid.ts";
-import { UserType } from "../user_type.ts";
 
 export const group_get_req = z.object({
   group_id: val_uuid_zod(),
-  user_type: z.enum([UserType.Owner, UserType.Manager, UserType.Member]),
 });
 
 export type GroupGetReq = z.infer<typeof group_get_req>;

--- a/quick-attendance-api/tests/test_group_invite_and_join_test.ts
+++ b/quick-attendance-api/tests/test_group_invite_and_join_test.ts
@@ -126,7 +126,7 @@ Deno.test(
       for (const entity of accept_member_entities) {
         await test_fetch_json(
           GROUP_AUTH_URL(test_num) +
-            `?group_id=${owner_group_list.owned_groups[0].group_id}&user_type=Member`,
+            `?group_id=${owner_group_list.owned_groups[0].group_id}`,
           "GET",
           entity.jwt,
           null,
@@ -141,7 +141,7 @@ Deno.test(
 
       await test_fetch_json(
         GROUP_AUTH_URL(test_num) +
-          `?group_id=${owner_group_list.owned_groups[0].group_id}&user_type=Owner`,
+          `?group_id=${owner_group_list.owned_groups[0].group_id}`,
         "GET",
         owner_jwt,
         null,


### PR DESCRIPTION
The group GET endpoint has been updated to determine the users type internally, this aims to prevent headaches in front-end code specified the @Daniel-Walbolt.
- Tests have been updated and are passing